### PR TITLE
Image Lab: Display Png metadata

### DIFF
--- a/frontend/frontend.py
+++ b/frontend/frontend.py
@@ -326,6 +326,7 @@ def draw_gradio_ui(opt, img2img=lambda x: x, txt2img=lambda x: x,imgproc=lambda 
                             #select folder with images to process
                                 with gr.TabItem('Batch Process'):
                                     imgproc_folder = gr.File(label="Batch Process", file_count="multiple",source="upload", interactive=True, type="file")
+                            imgproc_pngnfo = gr.Textbox(label="PNG Metadata", placeholder="PngNfo", visible=False, max_lines=5)
                             with gr.Row():
                                 imgproc_btn = gr.Button("Process", variant="primary")
                             gr.HTML("""
@@ -417,6 +418,12 @@ def draw_gradio_ui(opt, img2img=lambda x: x, txt2img=lambda x: x,imgproc=lambda 
                                                         [imgproc_source, imgproc_folder,imgproc_prompt,imgproc_toggles,
                                                         imgproc_upscale_toggles,imgproc_realesrgan_model_name,imgproc_sampling, imgproc_steps, imgproc_height, imgproc_width, imgproc_cfg, imgproc_denoising, imgproc_seed,imgproc_gfpgan_strength],
                                                         [imgproc_output])
+
+                                            imgproc_source.change(
+                                                        uifn.get_png_nfo,
+                                                        [imgproc_source],
+                                                        [imgproc_pngnfo] )
+
                                     output_txt2img_to_imglab.click(
                                         uifn.copy_img_to_lab,
                                         [output_txt2img_gallery],

--- a/frontend/ui_functions.py
+++ b/frontend/ui_functions.py
@@ -120,3 +120,12 @@ def resize_image(resize_mode, im, width, height):
 def update_dimensions_info(width, height):
     pixel_count_formated = "{:,.0f}".format(width * height)
     return f"Aspect ratio: {round(width / height, 5)}\nTotal pixel count: {pixel_count_formated}"
+
+def get_png_nfo( image: Image ):
+    info_text = ""
+    visible = bool(image and any(image.info))
+    if visible:
+        for key,value in image.info.items():
+            info_text += f"{key}: {value}\n"
+        info_text = info_text.rstrip('\n')
+    return gr.Textbox.update(value=info_text, visible=visible)

--- a/webui.py
+++ b/webui.py
@@ -31,7 +31,7 @@ parser.add_argument("--port", type=int, help="choose the port for the gradio web
 parser.add_argument("--precision", type=str, help="evaluate at this precision", choices=["full", "autocast"], default="autocast")
 parser.add_argument("--realesrgan-dir", type=str, help="RealESRGAN directory", default=('./src/realesrgan' if os.path.exists('./src/realesrgan') else './RealESRGAN'))
 parser.add_argument("--realesrgan-model", type=str, help="Upscaling model for RealESRGAN", default=('RealESRGAN_x4plus'))
-parser.add_argument("--save-metadata", action='store_true', help="Whether to embed the generation parameters in the sample images", default=False)
+parser.add_argument("--save-metadata", action='store_true', help="Store generation parameters in the output png. Drop saved png into Image Lab to read parameters", default=False)
 parser.add_argument("--share-password", type=str, help="Sharing is open by default, use this to set a password. Username: webui", default=None)
 parser.add_argument("--share", action='store_true', help="Should share your server on gradio.app, this allows you to use the UI from your mobile app", default=False)
 parser.add_argument("--skip-grid", action='store_true', help="do not save a grid, only individual samples. Helpful when evaluating lots of samples", default=False)


### PR DESCRIPTION
This adds a text box to Image Lab that displays the metadata
of any PNG files dropped on it. Can be used to read the info
saved with --save-metadata

[From upstream PR #528](https://github.com/hlky/stable-diffusion-webui/pull/528)